### PR TITLE
fix: 조회 실패 때 커스텀 에러 사용 하도록 변경, 어텐던스 아카데미 아이디 대신 아카대미 코드 받도록 수정

### DIFF
--- a/src/main/java/oneclass/oneclass/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/oneclass/oneclass/domain/attendance/controller/AttendanceController.java
@@ -54,13 +54,13 @@ public class AttendanceController {
     }
 
     // AttendanceController.java
-    @GetMapping("/academy/{academyId}/today")
+    @GetMapping("/academy/{academyCode}/today")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "학원별 오늘 출석 현황 조회", description = "특정 학원의 오늘자 전체 학생 출석 상태를 조회합니다.")
     public ResponseEntity<List<AttendanceResponse>> getTodayAttendanceByAcademy(
-            @PathVariable String academyId
+            @PathVariable String academyCode
     ) {
-        return ResponseEntity.ok(attendanceService.getTodayAttendanceByAcademy(academyId));
+        return ResponseEntity.ok(attendanceService.getTodayAttendanceByAcademy(academyCode));
     }
 
     @GetMapping(value = "/qr/{lessonId}/cached", produces = MediaType.IMAGE_PNG_VALUE)

--- a/src/main/java/oneclass/oneclass/domain/member/controller/MemberController.java
+++ b/src/main/java/oneclass/oneclass/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import oneclass.oneclass.domain.member.dto.request.*;
 import oneclass.oneclass.domain.member.dto.response.ResponseToken;
 import oneclass.oneclass.domain.member.dto.response.TeacherStudentsResponse;
+import oneclass.oneclass.domain.member.error.MemberError;
 import oneclass.oneclass.domain.member.error.TokenError;
 import oneclass.oneclass.domain.member.repository.MemberRepository;
 import oneclass.oneclass.domain.member.service.MemberService;
@@ -183,9 +184,8 @@ public class MemberController {
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/search/{username}")
     public ResponseEntity<ApiResponse<Long>> findMemberIdByUsername(@PathVariable String username) {
-        return memberService.findMemberIdByUsername(username)
-                .map(ApiResponse::success)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.ok(ApiResponse.success(null))); // 혹은 404 Not Found
+        Long memberId = memberService.findMemberIdByUsername(username)
+                .orElseThrow(() -> new CustomException(MemberError.NOT_FOUND));
+        return ResponseEntity.ok(ApiResponse.success(memberId));
     }
 }


### PR DESCRIPTION
fix: 조회 실패 때 커스텀 에러 사용 하도록 변경, 어텐던스 아카데미 아이디 대신 아카대미 코드 받도록 수정